### PR TITLE
Delete sessions after successful logout instead of before logout

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -29,7 +29,7 @@ export default function createController(config) {
   } = hooks;
 
   loginSuccessHooks.push(createAssuranceLevelAndAuthMethodHook(config));
-  preLogoutHooks.push(createDeleteSessionsHook(config));
+  logoutSuccessHooks.push(createDeleteSessionsHook(config));
 
 
   const service = createService(config);

--- a/test/logoutCallback.js
+++ b/test/logoutCallback.js
@@ -19,7 +19,7 @@ describe('GET /logout/callback', function onDescribe() {
       query: {
         state: '1234'
       },
-      get: () => host,
+      get: () => undefined,
       session: {
         save: (cb) => cb(),
         user: {},
@@ -59,7 +59,7 @@ describe('GET /logout/callback', function onDescribe() {
       query: {
         state: '1234'
       },
-      get: () => host,
+      get: () => undefined,
       session: {
         save: (cb) => cb(),
         user: {},


### PR DESCRIPTION
Deleting a session for an itsme authentication before the logout flow is started causes the flow to terminate in the consent app before the user is redirected to the itsme logout service. So when the user attempts to log in again, when the user reaches the itsme server to log in, the pre-existing session is used to automatically log the user in.

See: https://jira.antwerpen.be/browse/AUTH-394?focusedCommentId=227930&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-227930